### PR TITLE
Set a maximum log size of 100mb for production

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -2,9 +2,17 @@ version: '2'
 services:
   nginx:
     restart: always
+    log_opt:
+      max-size: 100m
   ckan:
     restart: always
+    log_opt:
+      max-size: 100m
   datapusher:
     restart: always
+    log_opt:
+      max-size: 100m
   solr:
     restart: always
+    log_opt:
+      max-size: 100m


### PR DESCRIPTION
Adds a configuration setting to `production.yml` image so that each container will have a maximum log size. Addresses issue where current production service has run out of space due to the `ckan` container's logfile.